### PR TITLE
Latest from voucher_swap, kernel_version, and a couple of iOS 12 (and A12) fixes

### DIFF
--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -828,7 +828,12 @@ find_kernel_pmap(void)
     if (!bof) {
         return 0;
     }
-    val = calc64(kernel, bof, call, 2);
+    if(kernel_version == 18) {
+        // iOS 12
+        val = calc64(kernel, bof, call, 8);
+    } else {
+        val = calc64(kernel, bof, call, 2);
+    }
     if (!val) {
         return 0;
     }

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -506,6 +506,7 @@ PREAD(FHANDLE fd, void *buf, size_t count, off_t offset)
 #endif
 
 static uint8_t *kernel = NULL;
+static uint8_t kernel_version = 0;
 static size_t kernel_size = 0;
 
 static addr_t xnucore_base = 0;
@@ -528,6 +529,7 @@ init_kernel(addr_t base, const char *filename)
 {
     size_t rv;
     uint8_t buf[0x4000];
+    uint8_t *vstr = NULL;
     unsigned i, j;
     const struct mach_header *hdr = (struct mach_header *)buf;
     FHANDLE fd = INVALID_HANDLE;
@@ -683,6 +685,13 @@ init_kernel(addr_t base, const char *filename)
 
         CLOSE(fd);
     }
+
+    vstr = boyermoore_horspool_memmem(kernel, kernel_size, (uint8_t *)"Darwin Kernel Version", strlen("Darwin Kernel Version"));
+
+    if (vstr) {
+        kernel_version = atoi((const char *)vstr + strlen("Darwin Kernel Version") + 1);
+    }
+
     return 0;
 }
 

--- a/patchfinder64.c
+++ b/patchfinder64.c
@@ -825,6 +825,26 @@ find_gPhysBase(void)
 }
 
 addr_t
+find_ptov_table(void)
+{
+    addr_t bof, val;
+    addr_t ref = find_strref("\"ml_static_vtop(): illegal VA:", 1, 0);
+    if (!ref) {
+        return 0;
+    }
+    ref -= kerndumpbase;
+    bof = bof64(kernel, xnucore_base, ref);
+    if (!bof) {
+        return 0;
+    }
+    val = calc64(kernel, bof, bof + 48, 8);
+    if (!val) {
+        return 0;
+    }
+    return val + kerndumpbase;
+}
+
+addr_t
 find_kernel_pmap(void)
 {
     addr_t call, bof, val;

--- a/patchfinder64.h
+++ b/patchfinder64.h
@@ -4,7 +4,7 @@
 int init_kernel(uint64_t base, const char *filename);
 void term_kernel(void);
 
-enum { SearchInCore, SearchInPrelink };
+enum { SearchInCore, SearchInPrelink, SearchInPPL };
 
 uint64_t find_register_value(uint64_t where, int reg);
 uint64_t find_reference(uint64_t to, int n, int prelink);
@@ -28,5 +28,16 @@ uint64_t find_sysbootnonce(void);
 uint64_t find_trustcache(void);
 uint64_t find_amficache(void);
 uint64_t find_allproc(void);
+uint64_t find_cache(int dynamic);
+
+uint64_t find_add_x0_x0_0x40_ret(void);
+uint64_t find_vnode_lookup(void);
+uint64_t find_vnode_put(void);
+uint64_t find_vfs_context_current(void);
+uint64_t find_rootvnode(void);
+uint64_t find_zone_map_ref(void);
+
+uint64_t find_pmap_initialize_legacy_static_trust_cache_ppl(void);
+uint64_t find_trust_cache_ppl(void);
 
 #endif

--- a/patchfinder64.h
+++ b/patchfinder64.h
@@ -10,6 +10,7 @@ uint64_t find_register_value(uint64_t where, int reg);
 uint64_t find_reference(uint64_t to, int n, int prelink);
 uint64_t find_strref(const char *string, int n, int prelink);
 uint64_t find_gPhysBase(void);
+uint64_t find_ptov_table(void);
 uint64_t find_kernel_pmap(void);
 uint64_t find_amfiret(void);
 uint64_t find_ret_0(void);


### PR DESCRIPTION
This PR has 5 commits:

- Sync with the version from xerub/voucher_swap
- Find the Darwin kernel version we are working on (used in the next commit)
- iOS 12 fix for find_kernel_pmap
- iOS 12 (and A12) fix for find_gPhysBase
- find_ptov_table()